### PR TITLE
Fix for october 420+

### DIFF
--- a/classes/Image.php
+++ b/classes/Image.php
@@ -269,7 +269,7 @@ class Image
         $width = (integer) $width;
         $height = (integer) $height;
         
-        return 'thumb__' . $width . 'x' . $height . '_' . $this->options['offset'][0] . '_' . $this->options['offset'][1] . '_' . $this->options['mode'] . '.' . $this->options['extension'];
+        return 'thumb__' . $width . '_' . $height . '_' . $this->options['offset'][0] . '_' . $this->options['offset'][1] . '_' . $this->options['mode'] . '.' . $this->options['extension'];
     }
 
     /**


### PR DESCRIPTION
On october build 420+ (laravel 5.5) this plugin does not work.   Here is the fix.

Fix for https://github.com/toughdeveloper/oc-imageresizer-plugin/issues/24 and https://github.com/toughdeveloper/oc-imageresizer-plugin/issues/25

